### PR TITLE
updated 06 lab ex 1 code by olaer and cruzado

### DIFF
--- a/src/pkg06labactivity/Main.java
+++ b/src/pkg06labactivity/Main.java
@@ -18,28 +18,28 @@ public class Main {
     public static void main(String[] args) {
         do {
             Scanner s = new Scanner(System.in);
-            System.out.println();
-            System.out.println("!  Day of Year Application  !");
-            System.out.println("Please enter a month: ");
-            String month = s.nextLine();
-            System.out.println("Please enter day of month: ");
-            String dayOfMonth = s.nextLine();
-            System.out.println("Please enter year: ");
-            String year = s.nextLine();
 
-            int dayOfYear = dayOfYear(Integer.parseInt(month),
-                    Integer.parseInt(dayOfMonth), Integer.parseInt(year));
+            System.out.println("!  Day of Year Application  !");
+            System.out.println("Please enter a month (enter its number instead of the name): ");
+            int month = s.nextInt();
+            System.out.println("Please enter day of month: ");
+            int dayOfMonth = s.nextInt();
+            System.out.println("Please enter year: ");
+            int year = s.nextInt();
+            
+            int dayOfYear = dayOfYear(month, dayOfMonth, year);
 
             System.out.println("Day of year is " + dayOfYear);
             System.out.println();
             
             System.out.println("Do you want to start over? [y/n]");
-            String res = s.nextLine();
-            if(res.equalsIgnoreCase("n")) {
+            char res = s.next().charAt(0);
+            if(res == 'n') {
                 break;
-            }     
+            }
         } while (true);
     }
+    
     
     // this function will return the day of year based on the input
     // month, day of month, and year.
@@ -47,31 +47,79 @@ public class Main {
     // and year is 2024. the output will be 5 (5th day of the year).
     // another example, if month is February, day of month is 23rd of February,
     // and year is 2023. the output will be 54 (54th day of the year).
+    
     public static int dayOfYear(int month, int dayOfMonth, int year) {
-        if (month == 2) {
-            dayOfMonth += 31;
-        } else if (month == 3) {
-            dayOfMonth += 59;
-        } else if (month == 4) {
-            dayOfMonth += 90;
-        } else if (month == 5) {
-            dayOfMonth += 31 + 28 + 31 + 30;
-        } else if (month == 6) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31;
-        } else if (month == 7) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30;
-        } else if (month == 8) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31;
-        } else if (month == 9) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31;
-        } else if (month == 10) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30;
-        } else if (month == 11) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31;
-        } else if (month == 12) {
-            dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 31;
+        switch (month) {
+            case 1:
+                dayOfMonth += 0;
+                break;
+            case 2:
+                dayOfMonth += 31;
+                break;
+            case 3:
+                dayOfMonth += 31 + 28;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 4:
+                dayOfMonth += 31 + 28 + 31;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 5:
+                dayOfMonth += 31 + 28 + 31 + 30;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 6:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 7:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 8:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 9:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 10:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 11:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
+            case 12:
+                dayOfMonth += 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30;
+                if(year %4 == 0){
+                    dayOfMonth += 1;
+                }
+                break;
         }
+        
         return dayOfMonth;
+        
     }
     
 }


### PR DESCRIPTION
defect 1 - no instruction about month was specified; a user might enter the name of the month instead of entering the number of the month (i.e. January is 1, June is 6, etc.) [ADDED]

defect 2 - in lines 44 and 46, the numbers are directly added instead of being separately shown. [CORRECTED]

defect 3 -  there is no condition for leap year [ADDED]

defect 4 - despite there being no line of code to indicate for janurary [(month == 1) or case: 1], the code somehow still works and runs as if a code for january exists. [ADDED]

defect 5 - lines 41 to 65 are using if-else statements [FIXED]

defect 6 - line spacing is not necessary [FIXED]

defect 7 - unnecessary parsing in line 20 - 21 [FIXED]